### PR TITLE
Modify error.html to use absolute image path

### DIFF
--- a/06-S3/static_website_hosting/website_files/error.html
+++ b/06-S3/static_website_hosting/website_files/error.html
@@ -4,6 +4,6 @@
     </head>
     <body>
         <h1><Center>Another Cat won the top10 - clearly there is an error</Center></h1>
-        <center><img src="img/thejudge.jpg"></center>
+        <center><img src="/img/thejudge.jpg"></center>
     </body>
 </html>


### PR DESCRIPTION
Currently, when a non-existent nested URL is accessed (e.g. `/foo/bar/baz.png`), the error page loads but `thejudge.jpg` doesn't.