### PR TITLE
mysql snapshot mismatch in the high availability section

### DIFF
--- a/14-HA-and-Scaling/01_ElasticCatBLog-Part1-LaunchTemplate/01_DEMO_SETUP/02c_A4L_RDSDB.yaml
+++ b/14-HA-and-Scaling/01_ElasticCatBLog-Part1-LaunchTemplate/01_DEMO_SETUP/02c_A4L_RDSDB.yaml
@@ -46,7 +46,7 @@ Resources:
       DBSubnetGroupName: !Ref RDSSubnetGroup
       DBName: !If [NoSnapshot,  '{{resolve:ssm:/A4L/Wordpress/DBName:1}}', !Ref 'AWS::NoValue' ]
       Engine: MySQL
-      EngineVersion: "5.6.46"
+      EngineVersion: "5.7.31"
       MasterUserPassword: !If [NoSnapshot, '{{resolve:ssm-secure:/A4L/Wordpress/DBPassword:1}}', !Ref 'AWS::NoValue' ] 
       MasterUsername: !If [NoSnapshot, '{{resolve:ssm:/A4L/Wordpress/DBUser:1}}', !Ref 'AWS::NoValue' ]
       MultiAZ: !Ref MultiAZ

--- a/14-HA-and-Scaling/01_ElasticCatBLog-Part1-LaunchTemplate/ZZ_DEMO_ENDSTATE/02b_A4L_RDSDB.yaml
+++ b/14-HA-and-Scaling/01_ElasticCatBLog-Part1-LaunchTemplate/ZZ_DEMO_ENDSTATE/02b_A4L_RDSDB.yaml
@@ -46,7 +46,7 @@ Resources:
       DBSubnetGroupName: !Ref RDSSubnetGroup
       DBName: !If [NoSnapshot,  '{{resolve:ssm:/A4L/Wordpress/DBName:1}}', !Ref 'AWS::NoValue' ]
       Engine: MySQL
-      EngineVersion: "5.6.46"
+      EngineVersion: "5.7.31"
       MasterUserPassword: !If [NoSnapshot, '{{resolve:ssm-secure:/A4L/Wordpress/DBPassword:1}}', !Ref 'AWS::NoValue' ] 
       MasterUsername: !If [NoSnapshot, '{{resolve:ssm:/A4L/Wordpress/DBUser:1}}', !Ref 'AWS::NoValue' ]
       MultiAZ: !Ref MultiAZ

--- a/14-HA-and-Scaling/02_ElasticCatBLog-Part2-Autoscaling Group/01_DEMO_SETUP/02b_A4L_RDSDB.yaml
+++ b/14-HA-and-Scaling/02_ElasticCatBLog-Part2-Autoscaling Group/01_DEMO_SETUP/02b_A4L_RDSDB.yaml
@@ -46,7 +46,7 @@ Resources:
       DBSubnetGroupName: !Ref RDSSubnetGroup
       DBName: !If [NoSnapshot,  '{{resolve:ssm:/A4L/Wordpress/DBName:1}}', !Ref 'AWS::NoValue' ]
       Engine: MySQL
-      EngineVersion: "5.6.46"
+      EngineVersion: "5.7.31"
       MasterUserPassword: !If [NoSnapshot, '{{resolve:ssm-secure:/A4L/Wordpress/DBPassword:1}}', !Ref 'AWS::NoValue' ] 
       MasterUsername: !If [NoSnapshot, '{{resolve:ssm:/A4L/Wordpress/DBUser:1}}', !Ref 'AWS::NoValue' ]
       MultiAZ: !Ref MultiAZ

--- a/14-HA-and-Scaling/02_ElasticCatBLog-Part2-Autoscaling Group/ZZ_DEMO_ENDSTATE/02b_A4L_RDSDB.yaml
+++ b/14-HA-and-Scaling/02_ElasticCatBLog-Part2-Autoscaling Group/ZZ_DEMO_ENDSTATE/02b_A4L_RDSDB.yaml
@@ -46,7 +46,7 @@ Resources:
       DBSubnetGroupName: !Ref RDSSubnetGroup
       DBName: !If [NoSnapshot,  '{{resolve:ssm:/A4L/Wordpress/DBName:1}}', !Ref 'AWS::NoValue' ]
       Engine: MySQL
-      EngineVersion: "5.6.46"
+      EngineVersion: "5.7.31"
       MasterUserPassword: !If [NoSnapshot, '{{resolve:ssm-secure:/A4L/Wordpress/DBPassword:1}}', !Ref 'AWS::NoValue' ] 
       MasterUsername: !If [NoSnapshot, '{{resolve:ssm:/A4L/Wordpress/DBUser:1}}', !Ref 'AWS::NoValue' ]
       MultiAZ: !Ref MultiAZ

--- a/14-HA-and-Scaling/03_ElasticCatBLog-Part3-LoadBalancer/01_DEMO_SETUP/02b_A4L_RDSDB.yaml
+++ b/14-HA-and-Scaling/03_ElasticCatBLog-Part3-LoadBalancer/01_DEMO_SETUP/02b_A4L_RDSDB.yaml
@@ -43,7 +43,7 @@ Resources:
       DBSubnetGroupName: !Ref RDSSubnetGroup
       DBName: !If [NoSnapshot,  '{{resolve:ssm:/A4L/Wordpress/DBName:1}}', !Ref 'AWS::NoValue' ]
       Engine: MySQL
-      EngineVersion: "5.6.46"
+      EngineVersion: "5.7.31"
       MasterUserPassword: !If [NoSnapshot, '{{resolve:ssm-secure:/A4L/Wordpress/DBPassword:1}}', !Ref 'AWS::NoValue' ] 
       MasterUsername: !If [NoSnapshot, '{{resolve:ssm:/A4L/Wordpress/DBUser:1}}', !Ref 'AWS::NoValue' ]
       MultiAZ: !Ref MultiAZ


### PR DESCRIPTION
the snapshot we take in the RDS section is mysql 5.7. We were restoring it each time, so I was thinking the same would be true for the HA section. It failed during the stack creation with the mysql version mismatch.

Edited the cloudformation to use the new version. I went thru all the demos and never had any compatibility issues with wordpress and mysql 5.7.